### PR TITLE
Fix typo in settings key

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2303,7 +2303,7 @@ impl Furtherance {
                 charts_breakdown_by_selection_column = charts_breakdown_by_selection_column
                     .push(self.report.selection_time_recorded_chart.view());
             }
-            if self.fur_settings.show_chart_seleciton_earnings {
+            if self.fur_settings.show_chart_selection_earnings {
                 charts_breakdown_by_selection_column = charts_breakdown_by_selection_column
                     .push(self.report.selection_earnings_recorded_chart.view());
             }
@@ -2848,7 +2848,7 @@ impl Furtherance {
                             checkbox(
                                 self.localization
                                     .get_message("earnings-for-selection", None),
-                                self.fur_settings.show_chart_seleciton_earnings
+                                self.fur_settings.show_chart_selection_earnings
                             )
                             .on_toggle_maybe(
                                 if self.fur_settings.show_chart_breakdown_by_selection {

--- a/src/models/fur_settings.rs
+++ b/src/models/fur_settings.rs
@@ -87,7 +87,7 @@ impl Default for FurSettings {
             show_chart_average_time: true,
             show_chart_breakdown_by_selection: true,
             show_chart_earnings: true,
-            show_chart_seleciton_earnings: true,
+            show_chart_selection_earnings: true,
             show_chart_selection_time: true,
             show_chart_time_recorded: true,
             show_chart_total_earnings_box: true,
@@ -272,7 +272,7 @@ impl FurSettings {
         &mut self,
         value: &bool,
     ) -> Result<(), std::io::Error> {
-        self.show_chart_seleciton_earnings = value.to_owned();
+        self.show_chart_selection_earnings = value.to_owned();
         self.save()
     }
 

--- a/src/models/fur_settings.rs
+++ b/src/models/fur_settings.rs
@@ -48,7 +48,7 @@ pub struct FurSettings {
     pub show_chart_average_time: bool,
     pub show_chart_breakdown_by_selection: bool,
     pub show_chart_earnings: bool,
-    pub show_chart_seleciton_earnings: bool,
+    pub show_chart_selection_earnings: bool,
     pub show_chart_selection_time: bool,
     pub show_chart_time_recorded: bool,
     pub show_chart_total_earnings_box: bool,


### PR DESCRIPTION
`show_chart_selection_earnings`

was misspelled as

`show_chart_seleciton_earnings`