### PR TITLE
Added notification alarm sound feature and option to toggle the alarm in settings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -83,7 +83,11 @@ use iced_aw::{
 };
 use iced_fonts::{bootstrap::icon_to_char, Bootstrap, BOOTSTRAP_FONT};
 use itertools::Itertools;
-use notify_rust::{Notification, Timeout};
+use notify_rust::{
+    Notification, 
+    Timeout, 
+    Hint::{SuppressSound},
+};
 use palette::color_difference::Wcag21RelativeContrast;
 use palette::Srgb;
 use regex::Regex;
@@ -200,6 +204,7 @@ pub enum Message {
     SettingsPomodoroExtendedBreaksToggled(bool),
     SettingsPomodoroExtendedBreakIntervalChanged(u16),
     SettingsPomodoroExtendedBreakLengthChanged(i64),
+    SettingsPomodoroNotificationAlarmSoundToggled(bool),
     SettingsPomodoroLengthChanged(i64),
     SettingsPomodoroSnoozeLengthChanged(i64),
     SettingsPomodoroToggled(bool),
@@ -1657,6 +1662,11 @@ impl Furtherance {
                         .num_seconds(),
                 );
             }
+            Message::SettingsPomodoroNotificationAlarmSoundToggled(new_value) => {
+                if let Err(e) = self.fur_settings.change_pomodoro_notification_alarm_sound(&new_value) {
+                    eprintln!("Failed to change pomodoro_notification_alarm_sound in settings: {}", e);
+                }
+            }
             Message::SettingsReminderIntervalChanged(new_value) => {
                 if let Err(e) = self
                     .fur_settings
@@ -1675,7 +1685,7 @@ impl Furtherance {
             }
             Message::ShowReminderNotification => {
                 if !self.timer_is_running {
-                    show_notification(NotificationType::Reminder, &self.localization);
+                    show_notification(NotificationType::Reminder, &self.localization, self.fur_settings.pomodoro_notification_alarm_sound);
                 }
             }
             Message::SettingsServerChoiceSelected(new_value) => {
@@ -1856,12 +1866,13 @@ impl Furtherance {
                         // Check if idle or other alert is being displayed so as not to replace it
                         if self.displayed_alert.is_none() {
                             if self.pomodoro.on_break {
-                                show_notification(NotificationType::BreakOver, &self.localization);
+                                show_notification(NotificationType::BreakOver, &self.localization, self.fur_settings.pomodoro_notification_alarm_sound);
                                 self.displayed_alert = Some(FurAlert::PomodoroBreakOver);
                             } else {
                                 show_notification(
                                     NotificationType::PomodoroOver,
                                     &self.localization,
+                                    self.fur_settings.pomodoro_notification_alarm_sound,
                                 );
                                 self.displayed_alert = Some(FurAlert::PomodoroOver);
                             }
@@ -1886,7 +1897,7 @@ impl Furtherance {
                         {
                             // User is back - show idle message
                             self.idle.notified = true;
-                            show_notification(NotificationType::Idle, &self.localization);
+                            show_notification(NotificationType::Idle, &self.localization, self.fur_settings.pomodoro_notification_alarm_sound);
                             self.displayed_alert = Some(FurAlert::Idle);
                         }
                     }
@@ -3468,6 +3479,15 @@ impl Furtherance {
                     Scrollable::new(
                         column![
                             settings_heading(self.localization.get_message("pomodoro-timer", None)),
+                            row![
+                                text(self.localization.get_message("notification_alarm_sound", None)),
+                                toggler(self.fur_settings.pomodoro_notification_alarm_sound)
+                                    .on_toggle(Message::SettingsPomodoroNotificationAlarmSoundToggled)
+                                    .width(Length::Shrink)
+                                    .style(style::fur_toggler_style)
+                            ]
+                            .spacing(10)
+                            .align_y(Alignment::Center),
                             row![
                                 text(self.localization.get_message("countdown-timer", None)),
                                 toggler(self.fur_settings.pomodoro)
@@ -5374,25 +5394,31 @@ fn has_max_two_decimals(input: &str) -> bool {
     }
 }
 
-fn show_notification(notification_type: NotificationType, localization: &Localization) {
+fn show_notification(notification_type: NotificationType, localization: &Localization, notification_alarm_sound: bool) {
     let heading: String;
     let details: String;
+    let has_sound: bool;
+
     match notification_type {
         NotificationType::PomodoroOver => {
             heading = localization.get_message("pomodoro-over-title", None);
             details = localization.get_message("pomodoro-over-notification-body", None);
+            has_sound = true;
         }
         NotificationType::BreakOver => {
             heading = localization.get_message("break-over-title", None);
             details = localization.get_message("break-over-description", None);
+            has_sound = true;
         }
         NotificationType::Idle => {
             heading = localization.get_message("idle-notification-title", None);
             details = localization.get_message("idle-notification-body", None);
+            has_sound = false;
         }
         NotificationType::Reminder => {
             heading = localization.get_message("track-your-time", None);
             details = localization.get_message("did-you-forget", None);
+            has_sound = false;
         }
     }
 
@@ -5400,6 +5426,8 @@ fn show_notification(notification_type: NotificationType, localization: &Localiz
         .summary(&heading)
         .body(&details)
         .appname("Furtherance")
+        .sound_name(if has_sound && notification_alarm_sound {"alarm-clock-elapsed"} else {""})
+        .hint(SuppressSound(!has_sound || !notification_alarm_sound))
         .timeout(Timeout::Milliseconds(6000))
         .show()
     {

--- a/src/app.rs
+++ b/src/app.rs
@@ -86,7 +86,6 @@ use itertools::Itertools;
 use notify_rust::{
     Notification, 
     Timeout, 
-    Hint::{SuppressSound},
 };
 use palette::color_difference::Wcag21RelativeContrast;
 use palette::Srgb;
@@ -5441,7 +5440,6 @@ fn show_notification(notification_type: NotificationType, localization: &Localiz
         .body(&details)
         .appname("Furtherance")
         .sound_name(if has_sound && notification_alarm_sound {"alarm-clock-elapsed"} else {""})
-        .hint(SuppressSound(!has_sound || !notification_alarm_sound))
         .timeout(Timeout::Milliseconds(6000))
         .show()
     {

--- a/src/locales/de/main.ftl
+++ b/src/locales/de/main.ftl
@@ -95,6 +95,7 @@ days-to-show = Anzuzeigende Tage
 
 ### Pomodoro Settings
 pomodoro-timer = Pomodoro-Timer
+notification_alarm_sound = Benachrichtigungs-Alarmsound
 countdown-timer = Countdown-Timer
 timer-length = Timer-Länge
 break-length = Pausenlänge

--- a/src/locales/en-US/main.ftl
+++ b/src/locales/en-US/main.ftl
@@ -102,6 +102,7 @@ reminder-interval = Minutes between reminders
 
 ### Pomodoro Settings
 pomodoro-timer = Pomodoro timer
+notification_alarm_sound = Notification alarm sound
 countdown-timer = Countdown timer
 timer-length = Timer length
 break-length = Break length

--- a/src/locales/es/main.ftl
+++ b/src/locales/es/main.ftl
@@ -95,6 +95,7 @@ days-to-show = Días a mostrar
 
 ### Pomodoro Settings
 pomodoro-timer = Temporizador Pomodoro
+notification_alarm_sound = Sonido de alarma de notificación
 countdown-timer = Temporizador de cuenta regresiva
 timer-length = Duración del temporizador
 break-length = Duración del descanso

--- a/src/locales/fi/main.ftl
+++ b/src/locales/fi/main.ftl
@@ -95,6 +95,7 @@ days-to-show = Näytettävät päivät
 
 ### Pomodoro Settings
 pomodoro-timer = Pomodoro-ajastin
+notification_alarm_sound = Ilmoitusäänet hälytysääni
 countdown-timer = Lähtölaskenta-ajastin
 timer-length = Ajastimen pituus
 break-length = Tauon pituus

--- a/src/locales/fr/main.ftl
+++ b/src/locales/fr/main.ftl
@@ -96,6 +96,7 @@ days-to-show = Jours à afficher
 
 ### Pomodoro Settings
 pomodoro-timer = Minuteur Pomodoro
+notification_alarm_sound = Son d'alarme de notification
 countdown-timer = Compte à rebours
 timer-length = Durée du minuteur
 break-length = Durée de la pause

--- a/src/locales/it/main.ftl
+++ b/src/locales/it/main.ftl
@@ -95,6 +95,7 @@ days-to-show = Giorni da mostrare
 
 ### Pomodoro Settings
 pomodoro-timer = Timer Pomodoro
+notification_alarm_sound = Suono di allarme di notifica
 countdown-timer = Timer conto alla rovescia
 timer-length = Durata timer
 break-length = Durata pausa

--- a/src/locales/nl/main.ftl
+++ b/src/locales/nl/main.ftl
@@ -96,6 +96,7 @@ days-to-show = Te tonen dagen
 
 ### Pomodoro Settings
 pomodoro-timer = Pomodoro-tijdklok
+notification_alarm_sound = Meldingsalarmgeluid
 countdown-timer = Aftelklok
 timer-length = Tijdklokduur
 break-length = Pauzeduur

--- a/src/locales/pt-BR/main.ftl
+++ b/src/locales/pt-BR/main.ftl
@@ -96,6 +96,7 @@ days-to-show = Dias para mostrar
 
 ### Pomodoro Settings
 pomodoro-timer = Cronômetro Pomodoro
+notification_alarm_sound = Som de alarme de notificação
 countdown-timer = Cronômetro de contagem regressiva
 timer-length = Duração do cronômetro
 break-length = Duração da pausa

--- a/src/locales/pt-PT/main.ftl
+++ b/src/locales/pt-PT/main.ftl
@@ -95,6 +95,7 @@ days-to-show = Dias a mostrar
 
 ### Pomodoro Settings
 pomodoro-timer = Temporizador Pomodoro
+notification_alarm_sound = Som de alarme de notificação
 countdown-timer = Temporizador de contagem decrescente
 timer-length = Duração do temporizador
 break-length = Duração da pausa

--- a/src/locales/ru/main.ftl
+++ b/src/locales/ru/main.ftl
@@ -95,6 +95,7 @@ days-to-show = Количество дней для отображения
 
 ### Pomodoro Settings
 pomodoro-timer = Таймер Pomodoro
+notification_alarm_sound = Звук уведомления тревоги
 countdown-timer = Таймер обратного отсчета
 timer-length = Длительность таймера
 break-length = Длительность перерыва

--- a/src/locales/sk/main.ftl
+++ b/src/locales/sk/main.ftl
@@ -95,6 +95,7 @@ days-to-show = Počet dní na zobrazenie
 
 ### Pomodoro Settings
 pomodoro-timer = Pomodoro časovač
+notification_alarm_sound = Zvuk alarmu notifikácie
 countdown-timer = Odpočítavanie
 timer-length = Dĺžka časovača
 break-length = Dĺžka prestávky

--- a/src/locales/tr/main.ftl
+++ b/src/locales/tr/main.ftl
@@ -95,6 +95,7 @@ days-to-show = Gösterilecek gün sayısı
 
 ### Pomodoro Settings
 pomodoro-timer = Pomodoro zamanlayıcısı
+notification_alarm_sound = Bildirim alarm sesi
 countdown-timer = Geri sayım zamanlayıcısı
 timer-length = Zamanlayıcı uzunluğu
 break-length = Mola uzunluğu

--- a/src/models/fur_settings.rs
+++ b/src/models/fur_settings.rs
@@ -47,6 +47,7 @@ pub struct FurSettings {
     pub pomodoro_extended_break_length: i64,
     pub pomodoro_length: i64,
     pub pomodoro_snooze_length: i64,
+    pub pomodoro_notification_alarm_sound: bool,
     pub show_chart_average_earnings: bool,
     pub show_chart_average_time: bool,
     pub show_chart_breakdown_by_selection: bool,
@@ -89,6 +90,7 @@ impl Default for FurSettings {
             pomodoro_extended_break_length: 25,
             pomodoro_length: 25,
             pomodoro_snooze_length: 5,
+            pomodoro_notification_alarm_sound: true,
             show_chart_average_earnings: true,
             show_chart_average_time: true,
             show_chart_breakdown_by_selection: true,
@@ -254,6 +256,11 @@ impl FurSettings {
 
     pub fn change_pomodoro_snooze_length(&mut self, value: &i64) -> Result<(), std::io::Error> {
         self.pomodoro_snooze_length = value.to_owned();
+        self.save()
+    }
+
+    pub fn change_pomodoro_notification_alarm_sound(&mut self, value: &bool) -> Result<(), std::io::Error> {
+        self.pomodoro_notification_alarm_sound = value.to_owned();
         self.save()
     }
 


### PR DESCRIPTION
# What
This PR adds audio feedback whenever a countdown expires, along with an option to toggle the feature.

# Why
Audio feedback felt like a compelling addition to Furtherance, mainly because it improves non-computer-centric workflows, enabling the end user to maintain a consistent work rhythm, even when not actively viewing the screen.

# How
The alarm sound has been implemented using the already-present dependency notify-rust. The alarm plays only if the notification is of type PomodoroOver or BreakOver and the toggle Notification alarm sound is enabled. The alarm sound is the "alarm-clock-elapsed" type provided by the library.