### PR TITLE
Fix dynamic total for previous days

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3320,7 +3320,7 @@ impl Furtherance {
                 bottom: 0.0,
                 left: 20.0,
             });
-        for (i, (date, task_groups)) in self.task_history.iter().rev().enumerate() {
+        for (date, task_groups) in self.task_history.iter().rev() {
             let (total_time, total_earnings) = task_groups.iter().fold(
                 (0i64, 0f32),
                 |(accumulated_time, accumulated_earnings), group| {
@@ -3338,7 +3338,7 @@ impl Furtherance {
                 total_time,
                 total_earnings,
                 &self.fur_settings,
-                if i == 0 {
+                if self.timer_start_time.date_naive() == *date {
                     Some((self.timer_is_running, &self.timer_text))
                 } else {
                     None


### PR DESCRIPTION
While using the non-GTK rewrite of Furtherance, I encountered the following bug when using the "dynamic total" setting:<br/>
When starting or restarting a task, the current running timer would incorrectly increase the total time of the previous day if the current task was the first task of the day. This bug was caused by the timer implementation that would always provide the current running timer when rendering the _first row_ of the history view. However, Furtherance doesn't render a row for the current day if no tasks have been recorded (i.e. have ended), so the first row would point to a previous day.

Fix the bug by comparing the row's date with  the start time of the current running task instead of counting the rendered rows.

# Testing

To test this patch using an empty database, manually create a task for the previous day and then start an active task. With the patch applied, the total time for the previous day should no longer increase. Next, stop the active task and start another active task. This time, the total time _for the current day_ should increase.

---

Thank you for creating Furtherance! It's a tool I'm using daily to keep track of various tasks!